### PR TITLE
Add waitFor options to goXXX actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ Example request body:
         // if selectorOrTimeout is a string, then the first argument is treated as a selector or xpath, depending on whether or not it starts with '//', and the method is a shortcut for page.waitForSelector or page.waitForXPath
         // if selectorOrTimeout is a number, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
         "selectorOrTimeout": 5, //default timeout is 1000ms
-    }
- }
+    },
+    "navigationOptions": { // use if click triggers navigation to other page; same as in goXXX methods
+        "waitUntil": "domcontentloaded",    
+    } 
+}
 ```
 
 ### **/scroll**
@@ -94,7 +97,7 @@ Example request body:
     "selector": "", //<string> A selector to search for element to click. If there are multiple elements satisfying the selector, the first will be clicked.
     "waitOptions": {
         // if selectorOrTimeout is a string, then the first argument is treated as a selector or xpath, depending on whether or not it starts with '//', and the method is a shortcut for page.waitForSelector or page.waitForXPath
-        // if selectornOrTimeout is a number, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
+        // if selectorOrTimeout is a number, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
         "selectorOrTimeout": 5, //default timeout is 1000ms
     }
  }

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ This method allow to goto a page with a specific url in puppeteer.
 Params: 
 
 url - the url which puppeteer should navigate to.      
-options - [possible options to use for request.](https://github.com/GoogleChrome/puppeteer/blob/v1.20.0/docs/api.md#pagegotourl-options)
+navigationOptions - [possible options to use for request.](https://github.com/GoogleChrome/puppeteer/blob/v1.20.0/docs/api.md#pagegotourl-options)      
+waitOptions - [wait for selector or timeout](https://github.com/puppeteer/puppeteer/blob/v1.20.0/docs/api.md#pagewaitforselectororfunctionortimeout-options-args) after navigation completes, same as in click or scroll.
 
 ### **/back** and **/forward**
 This methods helps to navigate back and forward to see previously seen pages.
@@ -76,8 +77,8 @@ Example request body:
         "delay": 0 //<number> Time to wait between mousedown and mouseup in milliseconds. Defaults to 0.
     },
     "waitOptions": {
-        // if selectorOrFunctionOrTimeout is a string, then the first argument is treated as a selector or xpath, depending on whether or not it starts with '//', and the method is a shortcut for page.waitForSelector or page.waitForXPath
-        // if selectorOrFunctionOrTimeout is a number, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
+        // if selectorOrTimeout is a string, then the first argument is treated as a selector or xpath, depending on whether or not it starts with '//', and the method is a shortcut for page.waitForSelector or page.waitForXPath
+        // if selectorOrTimeout is a number, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
         "selectorOrTimeout": 5, //default timeout is 1000ms
     }
  }
@@ -92,8 +93,8 @@ Example request body:
 {
     "selector": "", //<string> A selector to search for element to click. If there are multiple elements satisfying the selector, the first will be clicked.
     "waitOptions": {
-        // if selectorOrFunctionOrTimeout is a string, then the first argument is treated as a selector or xpath, depending on whether or not it starts with '//', and the method is a shortcut for page.waitForSelector or page.waitForXPath
-        // if selectorOrFunctionOrTimeout is a number, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
+        // if selectorOrTimeout is a string, then the first argument is treated as a selector or xpath, depending on whether or not it starts with '//', and the method is a shortcut for page.waitForSelector or page.waitForXPath
+        // if selectornOrTimeout is a number, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
         "selectorOrTimeout": 5, //default timeout is 1000ms
     }
  }

--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -30,7 +30,20 @@ exports.closeContexts = async function closeContexts(browser, contextIds) {
     await Promise.all(close_promises);
 };
 
-exports.formResponse = async function formResponse(page, closePage) {
+async function wait(page, waitFor) {
+    if (waitFor instanceof Object) {
+        const {selectorOrTimeout, options} = waitFor;
+        if (selectorOrTimeout) {
+            await page.waitFor(selectorOrTimeout, options);
+        }
+    } else if (waitFor) {
+        await page.waitFor(waitFor);
+    }
+}
+
+exports.formResponse = async function formResponse(page, closePage, waitFor) {
+    await wait(page, waitFor);
+
     let response = {
         contextId: page.browserContext()._id,
         html: await page.content(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapy-puppeteer-service",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "start": "node ./bin/www"

--- a/routes/click.js
+++ b/routes/click.js
@@ -5,7 +5,14 @@ const router = express.Router();
 const DEFAULT_TIMEOUT = 1000;  // 1 second
 
 async function action(page, request) {
-    await page.click(request.body.selector, request.body.clickOptions);
+    if (request.body.navigationOptions) {
+        await Promise.all([
+            page.waitForNavigation(request.body.navigationOptions),
+            page.click(request.body.selector, request.body.clickOptions),
+        ]);
+    } else {
+        await page.click(request.body.selector, request.body.clickOptions);
+    }
     return utils.formResponse(page, request.query.closePage, request.body.waitOptions || DEFAULT_TIMEOUT);
 }
 
@@ -21,7 +28,8 @@ async function action(page, request) {
         // if selectorOrTimeout is a string, then the first argument is treated as a selector or xpath, depending on whether or not it starts with '//', and the method is a shortcut for page.waitForSelector or page.waitForXPath
         // if selectorOrTimeout is a number, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
         "selectorOrTimeout":... default 1,
-    }
+    },
+    "navigationOptions": {...} // same as in goto action
  }
  */
 router.post('/', async function (req, res, next) {

--- a/routes/click.js
+++ b/routes/click.js
@@ -5,12 +5,8 @@ const router = express.Router();
 const DEFAULT_TIMEOUT = 1000;  // 1 second
 
 async function action(page, request) {
-    await Promise.all([
-        page.waitFor(request.body.waitOptions.selectorOrTimeout || DEFAULT_TIMEOUT),
-        page.click(request.body.selector, request.body.clickOptions),
-    ]);
-
-    return utils.formResponse(page, request.query.closePage);
+    await page.click(request.body.selector, request.body.clickOptions);
+    return utils.formResponse(page, request.query.closePage, request.body.waitOptions || DEFAULT_TIMEOUT);
 }
 
 /**
@@ -22,8 +18,8 @@ async function action(page, request) {
         "delay" //<number> Time to wait between mousedown and mouseup in milliseconds. Defaults to 0.
     },
     "waitOptions": {
-        // if selectorOrFunctionOrTimeout is a string, then the first argument is treated as a selector or xpath, depending on whether or not it starts with '//', and the method is a shortcut for page.waitForSelector or page.waitForXPath
-        // if selectorOrFunctionOrTimeout is a number, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
+        // if selectorOrTimeout is a string, then the first argument is treated as a selector or xpath, depending on whether or not it starts with '//', and the method is a shortcut for page.waitForSelector or page.waitForXPath
+        // if selectorOrTimeout is a number, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
         "selectorOrTimeout":... default 1,
     }
  }

--- a/routes/goback.js
+++ b/routes/goback.js
@@ -4,8 +4,8 @@ const router = express.Router();
 
 
 async function action(page, request) {
-    await page.goBack(request.body.options);
-    return utils.formResponse(page, request.query.closePage);
+    await page.goBack(request.body.navigationOptions);
+    return utils.formResponse(page, request.query.closePage, request.body.waitOptions);
 }
 
 router.post('/', async function (req, res, next) {

--- a/routes/goforward.js
+++ b/routes/goforward.js
@@ -4,8 +4,8 @@ const router = express.Router();
 
 
 async function action(page, request) {
-    await page.goForward(request.body.options);
-    return utils.formResponse(page, request.query.closePage);
+    await page.goForward(request.body.navigationOptions);
+    return utils.formResponse(page, request.query.closePage, request.body.waitOptions);
 }
 
 router.post('/', async function (req, res, next) {

--- a/routes/goto.js
+++ b/routes/goto.js
@@ -4,13 +4,13 @@ const router = express.Router();
 
 
 async function action(page, request) {
-    await page.goto(request.body.url, request.body.options);
-    return utils.formResponse(page, request.query.closePage);
+    await page.goto(request.body.url, request.body.navigationOptions);
+    return utils.formResponse(page, request.query.closePage, request.body.waitOptions);
 }
 
 // body = {
 // "url": <string> URL to navigate page to. The url should include scheme, e.g. https://.
-// "options": { Navigation parameters which might have the following properties:
+// "navigationOptions": { Navigation parameters which might have the following properties:
 //     "timeout": <number> Maximum navigation time in milliseconds, defaults to 30 seconds, pass 0 to disable timeout. The default value can be changed by using the page.setDefaultNavigationTimeout(timeout) or page.setDefaultTimeout(timeout) methods.
 //     "waitUntil": <string|Array<string>> When to consider navigation succeeded, defaults to load. Given an array of event strings, navigation is considered to be successful after all events have been fired. Events can be either:
 //          load - consider navigation to be finished when the load event is fired.
@@ -18,7 +18,9 @@ async function action(page, request) {
 //          networkidle0 - consider navigation to be finished when there are no more than 0 network connections for at least 500 ms.
 //          networkidle2 - consider navigation to be finished when there are no more than 2 network connections for at least 500 ms.
 //     "referer" <string> Referer header value. If provided it will take preference over the referer header value set by page.setExtraHTTPHeaders().
-// }
+// },
+// "waitOptions": {...} same as in click action
+//
 router.post('/', async function (req, res, next) {
 
     if (!req.body.url) {

--- a/routes/scroll.js
+++ b/routes/scroll.js
@@ -5,20 +5,15 @@ const router = express.Router();
 const DEFAULT_TIMEOUT = 1000;  // 1 second
 
 async function action(page, request) {
-    let promises = [];
     if (request.body.selector) {
-        promises.push(page.hover(request.body.selector));
+        await page.hover(request.body.selector);
     } else {
-        promises.push(page.evaluate(() => {
+        await page.evaluate(() => {
             // scroll down until the bottom of the page to trigger scroll event even at the bottom of a page
             window.scrollBy(0, document.body.scrollHeight)
-        }));
+        });
     }
-    promises.push(page.waitFor(request.body.waitOptions.selectorOrTimeout || DEFAULT_TIMEOUT));
-
-    await Promise.all(promises);
-
-    return utils.formResponse(page, request.query.closePage);
+    return utils.formResponse(page, request.query.closePage, request.body.waitOptions || DEFAULT_TIMEOUT);
 }
 
 // Method that scrolls page to a certain selector.


### PR DESCRIPTION
I need to add a delay between goto navigation and page state capture, so I added page.waitFor parameters to goXXX routes. Now these routes have two kinds of options: navigationOptions and waitOptions.

Also I modified click/scroll so waiting happens after interaction. I believe using Promise.all with click/scroll and waiting on selector which is already present on the page may result in wait resolving before interaction happens.