### PR TITLE
Context timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Here we list them all with their purpose.
 * `TOKEN_2CAPTCHA = undefined` - token of [2captcha service](https://2captcha.com)
 * `STEALTH_BROWSING = true` - should the service use the [stealth browsing](https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth) mode
 * `MAX_CONCURRENT_CONTEXTS = undefined` - should the service limit the number of contexts
+* `CONTEXT_TIMEOUT = 600000` - time (in ms) after the passage of which the context would close
 
 ## Notes on memory usage
 You need to explicitly close the browser tab once you don't need it (e.g. at the end of the parse method).

--- a/app.js
+++ b/app.js
@@ -22,6 +22,7 @@ const harRouter = require('./routes/har');
 const closeContextRouter = require('./routes/close_context');
 
 const middlewares = require('./helpers/middlewares');
+const timeoutContext = require('./helpers/timeout_context');
 const limitContext = require('./helpers/limit_context');
 const loggers = require("./helpers/loggers");
 
@@ -38,7 +39,9 @@ const VIEWPORT_HEIGHT = parseInt(process.env.VIEWPORT_HEIGHT) || 720;
 const TOKEN_2CAPTCHA = process.env.TOKEN_2CAPTCHA;
 const STEALTH_BROWSING = (process.env.STEALTH_BROWSING || "true").toLowerCase() === "true";
 const MAX_CONCURRENT_CONTEXTS = process.env.MAX_CONCURRENT_CONTEXTS === "Infinity" ? Infinity : parseInt(process.env.MAX_CONCURRENT_CONTEXTS);
+const CONTEXT_TIMEOUT = parseInt(process.env.CONTEXT_TIMEOUT) || 600000;  // 10 minutes
 
+timeoutContext.initTimeoutContext(CONTEXT_TIMEOUT);
 limitContext.initContextCounter(MAX_CONCURRENT_CONTEXTS);
 loggers.initLogger(LOG_LEVEL, LOG_FILE, LOGSTASH_HOST, LOGSTASH_PORT);
 

--- a/helpers/timeout_context.js
+++ b/helpers/timeout_context.js
@@ -1,0 +1,58 @@
+const {BrowserContext} = require('puppeteer');
+const loggers = require('./loggers');
+
+/**
+ * ContextId -> Timeout timer' IDs
+ *
+ * @type {{string: number}}
+ */
+let contextTimeoutIds = {};
+let contextTimeout;
+
+/**
+ * Set timeout for context.
+ *
+ * @param {BrowserContext} context
+ */
+function setContextTimeout(context) {
+    const logger = loggers.getLogger();
+
+    contextTimeoutIds[context.id] = setTimeout(
+        async () => {
+            logger.warn(`Closing context ${context.id} due to timeout\n`);
+            await context.close();
+            delete contextTimeoutIds[context.id];
+        },
+        contextTimeout);
+}
+exports.setContextTimeout = setContextTimeout;
+
+/**
+ * The function clears context's timeout timer.
+ *
+ * @param {BrowserContext} context context to be cleared
+ */
+function clearContextTimeout(context) {
+    clearTimeout(contextTimeoutIds[context.id]);
+    delete contextTimeoutIds[context.id];
+}
+exports.clearContextTimeout = clearContextTimeout;
+
+/**
+ * Update timeout for context.
+ *
+ * @param {BrowserContext} context
+ */
+exports.updateContextTimeout = function updateContextTimeout (context) {
+    clearContextTimeout(context);
+    setContextTimeout(context);
+}
+
+/**
+ * Init service that timeouts contexts after CONTEXT_TIMEOUT ms.
+ *
+ * @param {number} timeout
+ */
+exports.initTimeoutContext = function initTimeoutContext (timeout) {
+    contextTimeout = timeout;
+}


### PR DESCRIPTION
# Description

Sometimes scrapy crawler do not close contexts due to local problems with spiders. With this timeout_context module the service will be able to close all hanging contexts.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested it with several local spider and implemented new one:
```
class ContextTimeoutSpider(scrapy.Spider):
    name = "context_timeout"

    def start_requests(self):
        url = "https://pptr.dev/"
        yield PuppeteerRequest(
            url,
            close_page=False,
            callback=self.await_minute,
            errback=self.error,
        )

    async def await_minute(self, response: PuppeteerHtmlResponse):
        await sleep(60)
        yield response.follow(
            Screenshot(options={"fullPage": True}),
            close_page=False,
            callback=self.parse,
            errback=self.error,
        )

    def parse(self, response: PuppeteerScreenshotResponse, **kwargs):
        assert False

    def error(self, failure: Failure):
        assert failure.value.response.status == 422  # Context not found
        self.log("Spider worked fine!")
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings