### PR TITLE
Increase captcha solver timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Example request body:
 ```json5
 {
     "waitOptions": {  // selector, xpath or timeout, same as in the goto method
-        "timeout": 5000, //default timeout is 1000ms
+        "timeout": 5000, // timeout in milliseconds, default is 30000
     },
     "solve_recaptcha": true,  // Whether to solve recaptcha on the page or not
     "close_on_empty": false,  // Whether to close the page if there was no recaptcha

--- a/actions/recaptcha_solver.js
+++ b/actions/recaptcha_solver.js
@@ -1,7 +1,7 @@
 const utils = require('../helpers/utils')
 const exceptions = require("../helpers/exceptions");
 
-const DEFAULT_TIMEOUT = 1000;  // 1 second
+const DEFAULT_TIMEOUT = 30000;  // 30 seconds
 
 /**
  * The function solves recaptchas on the page.
@@ -26,7 +26,7 @@ exports.recaptchaSolver = async function recaptchaSolver(page, request) {
         recaptchaData = await page.findRecaptchas();
     }
 
-    const waitOptions = request.body.waitOptions || { timeout: DEFAULT_TIMEOUT };
+    const waitOptions = request.body.waitOptions || {timeout: DEFAULT_TIMEOUT};
     const contents = await utils.getContents(page, waitOptions);
 
     if (request.query.closePage ||

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapy-puppeteer-service",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "scripts": {
     "start": "node ./bin/www"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapy-puppeteer-service",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "scripts": {
     "start": "node ./bin/www"


### PR DESCRIPTION
# Title

Increase captcha solver timeout

# Description

Just increases default wait after captcha solving so the page has time to redirect. This is a temporary solution, we should make it configurable, enable passing wait options on client and/or wait for navigation event.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It hasn't.