### PR TITLE
Accept insecure certs on websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Here we list them all with their purpose.
 * `LOGSTASH_HOST = undefined` - host address of the logstash
 * `LOGSTASH_PORT = undefined` - port of the logstash server
 * `HEADLESS = true` - should the service use the "headless" mode
+* `ACCEPT_INSECURE_CERTS = false` - should the service allow navigation on sites with insecure certificate
 * `CONNECT_TIMEOUT = 180000` - Maximum time in milliseconds to wait for the browser to start
 * `VIEWPORT_WIDTH = 1280` - width of the browser's window
 * `VIEWPORT_HEIGHT = 720` - height of the browser's window

--- a/app.js
+++ b/app.js
@@ -37,6 +37,7 @@ const LOG_FILE = process.env.LOG_FILE;
 const LOGSTASH_HOST = process.env.LOGSTASH_HOST;
 const LOGSTASH_PORT = process.env.LOGSTASH_PORT;
 const HEADLESS = (process.env.HEADLESS || "true").toLowerCase() === "true";
+const ACCEPT_INSECURE_CERTS = (process.env.ACCEPT_INSECURE_CERTS || "false").toLowerCase() === "true";
 const CONNECT_TIMEOUT = parseInt(process.env.CONNECT_TIMEOUT) || 180000;
 const VIEWPORT_WIDTH = parseInt(process.env.VIEWPORT_WIDTH) || 1280;
 const VIEWPORT_HEIGHT = parseInt(process.env.VIEWPORT_HEIGHT) || 720;
@@ -75,6 +76,7 @@ async function setupBrowser() {
         //TODO add more params for puppeteer launch
         const browser = await puppeteer.launch(
             {
+                acceptInsecureCerts: ACCEPT_INSECURE_CERTS,
                 headless: HEADLESS,
                 defaultViewport: { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT },
                 timeout: CONNECT_TIMEOUT,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapy-puppeteer-service",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "scripts": {
     "start": "node ./bin/www"


### PR DESCRIPTION
# Description

Currently, it is sometimes imposible to navigate to websites with bad certificate. This PR allows to ignore insecure certificates.
For the sake of implemetation added `ACCEPT_INSECURE_CERTS` (with default value of `false`).  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested it locally with my Scrapy spider.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings